### PR TITLE
Kill horizontal scroll in speakers list 🔥

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
     "ng2-modal": "0.0.25"
   },
   "devDependencies": {
+    "@angular/compiler-cli": "^2.3.1",
     "@types/jasmine": "^2.2.30",
     "@types/node": "^6.0.42",
     "angular-cli": "1.0.0-beta.19-3",

--- a/client/src/app/speakers/speakers.component.css
+++ b/client/src/app/speakers/speakers.component.css
@@ -8,13 +8,13 @@
 }
 
 #main-content > .row {
-    overflow-x:scroll;
-    overflow-y:hidden;
+    overflow-x:visible;
+    overflow-y:visible;
     white-space:nowrap;
 }
 
 #main-content > .row [class*="col-lg"], #main-content > .row [class*="col-md"], #main-content > .row [class*="col-sm"] {
-    float:none;
+    float:left;
     display:inline-block;
     overflow: hidden;
     height: 250px;


### PR DESCRIPTION
It is very very confusing UX to have horizontal scrolling on the speakers list. Many people I've spoken to have been confused by why there are only two speakers listed on the site. Users are simply not used to side scrolling, especially when there is no indicator that they should do so. Users are, however, used to scrolling vertically. This fixes scrolling to be vertical and shows all speakers by default in a normal grid layout.

<img width="1323" alt="screen shot 2017-06-23 at 8 29 21 am" src="https://user-images.githubusercontent.com/108938/27484343-7bddc2b4-57ee-11e7-890d-7de24afaa50f.png">

